### PR TITLE
Bugfix: De-squash research team photos, add black and white filter.

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,13 +12,13 @@
   <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,600' rel='stylesheet' type='text/css'>
   <link href='https://fonts.googleapis.com/css?family=Hind:500,600' rel='stylesheet' type='text/css'>
-  
+
   <link rel="stylesheet" href="css/normalize.css">
   <link rel="stylesheet" href="css/report.css">
   <script src="js/vendor/modernizr-2.8.3.min.js"></script>
 </head>
 <body>
-  
+
   <div id="main">
     <header class="clearfix">
 
@@ -27,12 +27,12 @@
       <!-- hamburger icon (uses fontawesome icon) -->
       <i class="fa fa-bars hamburger"></i>
       <ul id="menu" class="nav_highlight">
-        
+
        <li class><h2><a href="index.html">Our Research</a></h2></li>
        <li><h2><a href="about.html">Our Team</a></h2></li>
      </ul>
    </nav>
-   
+
  </header>
 
  <div id="wrapper">
@@ -40,7 +40,6 @@
    <div id="side_wrapper">
 
     <aside id="sidebar">
-     
 
       <div class="category">
         <h3 class="sidebar_title">Contact Us: </h3>
@@ -56,61 +55,63 @@
 
   <div id="researchers" class="clearfix">
 
-   <div class="title">
+  <div class="title">
     <h3>Firefox User Research Team</h3>
   </div>
 
   <article>
-   <p>Hello from Firefox's User Research team! We are a small group of design and user experience researchers working alongside the <a href="http://design.firefox.com/">Firefox Design</a> and Product teams to understand and serve our users around the world. We use a wide range of qualitative and quantitative research methods to inform product development and strategy.</p>
-   <br>
+    <p>Hello from Firefox's User Research team! We are a small group of design and user experience researchers working alongside the <a href="http://design.firefox.com/">Firefox Design</a> and Product teams to understand and serve our users around the world. We use a wide range of qualitative and quantitative research methods to inform product development and strategy.</p>
+    <br>
 
-  <p>The primary purpose of this website is to connect our Mozilla colleagues to previous research. We will be adding in blog posts, abstracts, and public reports when they are available.</p>
-   <br>
+    <p>The primary purpose of this website is to connect our Mozilla colleagues to previous research. We will be adding in blog posts, abstracts, and public reports when they are available.</p>
+    <br>
 
-   <p>If you are interested in joining our team, keep an eye on our open <a href="https://careers.mozilla.org/en-US/">Mozilla Jobs</a>!</p>
- </article>
+    <p>If you are interested in joining our team, keep an eye on our open <a href="https://careers.mozilla.org/en-US/">Mozilla Jobs</a>!</p>
+  </article>
 
- <div class="bios clearfix"><img src="img/researchers/sharon.jpg" alt="Sharon">
-   <h6>Sharon Bautista</h6>
-   <p>Senior User Researcher <br>Chicago, IL</p>
- </div>
+  <div class="bios clearfix">
+    <div class="profile-image" id="sharon"></div>
+    <h6>Sharon Bautista</h6>
+    <p>Senior User Researcher <br>Chicago, IL</p>
+  </div>
 
-  <div class="bios clearfix"><img src="img/researchers/jennifer.jpg" alt="Jennifer">
-   <h6>Jennifer Davidson</h6>
-   <p>Staff User Researcher <br>Seattle, WA</p>
- </div>
+    <div class="bios clearfix">
+    <div class="profile-image" id="jennifer"></div>
+    <h6>Jennifer Davidson</h6>
+    <p>Staff User Researcher <br>Seattle, WA</p>
+  </div>
 
-  
-  
+    <div class="bios clearfix">
+    <div class="profile-image" id="heather"></div>
+    <h6>Heather McGaw</h6>
+    <p>Staff User Researcher <br>Toronto, ON</p>
+  </div>
 
-  <div class="bios clearfix"><img src="img/researchers/heather.jpg" alt="Heather">
-   <h6>Heather McGaw</h6>
-   <p>Staff User Researcher <br>Toronto, ON</p>
- </div>
+  <div class="bios clearfix">
+    <div class="profile-image" id="alice"></div>
+    <h6>Alice Rhee</h6>
+    <p>User Researcher <br>Spartanburg, SC </p>
+  </div>
 
- <div class="bios clearfix"><img src="firefoxur.github.io/img/researchers/Alice.jpg" height="150" width="150">
-  <h6>Alice Rhee</h6>
-  <p>User Researcher <br>Spartanburg, SC </p>
-</div>
+  <div class="bios clearfix">
+    <div class="profile-image" id="nicole"></div>
+    <h6>Nicole Love</h6>
+    <p>Senior User Researcher <br>Chicago, IL </p>
+  </div>
 
-<div class="bios clearfix"><img src="firefoxur.github.io/img/researchers/nicole.jpg" height="150" width="150">
-  <h6>Nicole Love</h6>
-  <p>Senior User Researcher <br>Chicago, IL </p>
-</div>
+  <div class="bios clearfix">
+    <div class="profile-image" id="gemma"></div>
+    <h6>Gemma Petrie</h6>
+    <p>Senior Staff User Researcher <br>Seattle, WA</p>
+  </div>
 
- <div class="bios clearfix"><img src="img/researchers/gemma.jpg" alt="Gemma">
-  <h6>Gemma Petrie</h6>
-  <p>Senior Staff User Researcher <br>Seattle, WA</p>
-</div>
+  <div class="bios clearfix">
+    <div class="profile-image" id="mara"></div>
+    <h6>Mara Schwarzlose</h6>
+    <p>Team Administrator <br>Portland, OR</p>
+  </div>
 
-
-<div class="bios clearfix"><img src="firefoxur.github.io/img/researchers/mara.jpg" height="150" width="150">
-  <h6>Mara Schwarzlose</h6>
-  <p>Team Administrator <br>Portland, OR</p>
-</div>
- 
-
-</div>
+  </div>
 </div>
 
 <footer class="clearfix">

--- a/css/report.css
+++ b/css/report.css
@@ -215,6 +215,10 @@
     display: none;
   }
 
+/* ----------------------------------------------------
+   R E S E A R C H E R S
+   ------------------------------------------------------- */
+
   #report, #researchers  {
    width: 70%;
    margin-top: 0rem;
@@ -230,6 +234,45 @@
 .bios p {
   margin-left: 0;
 }
+
+.profile-image {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  filter: grayscale(100%);
+  height: 150px;
+  width: 150px;
+}
+
+#sharon {
+  background-image: url('../img/researchers/sharon.jpg');
+}
+
+#jennifer {
+  background-image: url('../img/researchers/jennifer.jpg');
+}
+
+#heather {
+  background-image: url('../img/researchers/heather.jpg');
+}
+
+#alice {
+  background-image: url('../img/researchers/alice.jpg');
+}
+
+#nicole {
+  background-image: url('../img/researchers/nicole.jpg');
+}
+
+#gemma {
+  background-image: url('../img/researchers/gemma.jpg');
+}
+
+#mara {
+  background-image: url('../img/researchers/mara.jpg');
+}
+
+
 
 /* ----------------------------------------------------
    N A V I G A T I O N
@@ -603,7 +646,7 @@ h3 {
 /* ----------------------------------------------------
    O V E R W R I T E
    ------------------------------------------------------- */
-   
+
    /*T A B L E T*/
 
    @media only screen and (max-width: 900px) {


### PR DESCRIPTION
Currently some images of researchers on /about appear squashed to conform to size & are not uniformly in black & white. This bugfix applies a black and white filter to all researcher photos and gives them a uniform size without distorting.

<img width="871" alt="Screen Shot 2019-03-12 at 12 40 56 PM" src="https://user-images.githubusercontent.com/30483988/54230655-1f3ed100-44c4-11e9-8cab-1fbf227662bb.png">
